### PR TITLE
Fixes #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /bin/
 /build/
 /target/
+/java-crypto-conditions.iml
+/.idea

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 group = 'org.interledger'
 description = 'Crypto Conditions'
-version = '2.0.0-SNAPSHOT'
+version = '2.0.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
@@ -11,8 +11,7 @@ apply plugin: 'jacoco'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-
-/* 
+/*
  custom checkstyle properties for the build.
  see https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html
 */
@@ -20,11 +19,11 @@ checkstyle {
     configFile file('google_checks.xml')
     toolVersion '7.1'
     showViolations = true
-    /* 
-       by default, checkstyle warnings dont fail the build. but we want exactly that for circle-ci 
-       pass/fail reporting, so tell the plugin to break the build on the first error 
+    /*
+       by default, checkstyle warnings dont fail the build. but we want exactly that for circle-ci
+       pass/fail reporting, so tell the plugin to break the build on the first error
     */
-	maxWarnings = 0 
+    maxWarnings = 0
 }
 
 jacocoTestReport {
@@ -37,11 +36,11 @@ jacocoTestReport {
 jar {
     manifest {
         attributes 'Implementation-Title': description,
-                   'Implementation-Version': version
+                'Implementation-Version': version
     }
 }
 
-repositories {    
+repositories {
     maven { url "http://repo.maven.apache.org/maven2" }
     mavenLocal()
 }
@@ -51,8 +50,10 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.bouncycastle:bcprov-jdk16:1.46'
     testCompile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
+    testCompile 'org.mockito:mockito-core:2.7.22'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'com.google.guava:guava:21.0'
 }
-
 
 task syncTestVectors(type: Sync) {
     from 'test-data/test-vectors'
@@ -71,7 +72,7 @@ task writePom {
     doLast {
         pom {
             project {
-                inceptionYear '2016'            
+                inceptionYear '2016'
                 licenses {
                     license {
                         name 'The Apache Software License, Version 2.0'
@@ -83,10 +84,10 @@ task writePom {
                     "project.build.sourceEncoding" "UTF-8"
                     "maven.compiler.source" "1.8"
                     "maven.compiler.target" "1.8"
-                    "checkstyle.config.location" "google_checks.xml"                
+                    "checkstyle.config.location" "google_checks.xml"
                     "checkstyle.consoleOutput" "true"
                 }
-                reporting  {
+                reporting {
                     plugins {
                         plugin {
                             groupId "org.apache.maven.plugins"
@@ -98,7 +99,7 @@ task writePom {
                         plugin {
                             groupId "org.apache.maven.plugins"
                             artifactId "maven-javadoc-plugin"
-                            version "2.10.4"                        
+                            version "2.10.4"
                         }
                     }
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.interledger</groupId>
   <artifactId>java-crypto-conditions</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <inceptionYear>2016</inceptionYear>
   <licenses>
     <license>
@@ -43,6 +43,24 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.7.22</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>21.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/interledger/cryptoconditions/Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/Condition.java
@@ -3,53 +3,54 @@ package org.interledger.cryptoconditions;
 import java.net.URI;
 
 /**
- * Java implementation of Crypto-conditions
+ * Java implementation of Crypto-Conditions Condition.
  *
- * @see <a href="https://datatracker.ietf.org/doc/draft-thomas-crypto-conditions/">
- * https://datatracker.ietf.org/doc/draft-thomas-crypto-conditions/</a>
- * 
  * @author adrianhopebailie
- *
+ * @see<a href="https://datatracker.ietf.org/doc/draft-thomas-crypto-conditions/">
+ * https://datatracker.ietf.org/doc/draft-thomas-crypto-conditions/</a>
  */
 public interface Condition {
 
   /**
    * The type identifier representing the condition type.
-   * 
+   *
    * @return the type of this condition
    */
   ConditionType getType();
 
   /**
-   * A binary string uniquely representing the condition with respect to other conditions of the
-   * same type. Implementations which index conditions MUST use the entire string or binary encoded
-   * condition as the key, not just the fingerprint - as different conditions of different types may
-   * have the same fingerprint.
-   * 
+   * A fingerprint is a binary (aka "octet") string uniquely representing the condition with respect
+   * to other conditions of the same type. Implementations which index conditions MUST use the
+   * entire string or binary encoded condition as the key - not just the fingerprint - as different
+   * conditions of different types may have the same fingerprint.
+   *
    * The length and contents of the fingerprint are defined by the condition type. The fingerprint
    * is a cryptographically secure hash of the data which defines the condition, such as a public
    * key.
-   * 
+   *
    * @return the unique fingerprint of this condition
    */
   byte[] getFingerprint();
 
   /**
    * The estimated "cost" of processing a fulfillment of this condition. For details of how to
-   * calculate this number see the crypto-conditions specification.
-   * 
-   * @return the cost of validating the fulfillment of this condition.
+   * calculate this number see the Crypto-conditions specification.
+   *
+   * @return the cost of validating the fulfillment of this condition
    */
   long getCost();
 
   /**
-   * Returns the DER encoded condition.
+   * Get the condition encoded in ASN.1 DER binary encoding.
+   *
+   * @return the DER encoded condition
    */
   byte[] getEncoded();
 
   /**
-   * Returns the Named Information URL that describes this condition.
+   * Get the Named Information URL that describes this condition.
+   *
+   * @return an ni:// URI that identifes this condition
    */
   URI getUri();
-
 }

--- a/src/main/java/org/interledger/cryptoconditions/types/PreimageSha256Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/types/PreimageSha256Condition.java
@@ -4,32 +4,45 @@ import org.interledger.cryptoconditions.ConditionType;
 import org.interledger.cryptoconditions.Sha256Condition;
 import org.interledger.cryptoconditions.SimpleCondition;
 
+import java.util.Arrays;
+
 /**
- * Implementation of a condition based on a preimage and the SHA-256 function.
+ * This type of condition is also called a "hashlock".  By creating a hash of a difficult-to-guess,
+ * 256-bit, random or pseudo-random integer, it is possible to create a condition which the creator
+ * can trivially fulfill by publishing the random value used to create the condition (the
+ * original random value is also referred to as a "preimage"). For anyone else, a hashlock
+ * condition is cryptographically hard to fulfill because one would have to find a preimage for
+ * the given condition hash.
  */
 public class PreimageSha256Condition extends Sha256Condition implements SimpleCondition {
 
-  private byte[] preimage;
+  private final byte[] preimage;
 
   /**
-   * Constructs an instance of the condition.
-   * 
-   * @param preimage The preimage associated with this condition.
+   * Required-args Constructor.  Constructs an instance of {@link PreimageSha256Condition} based
+   * on a supplied preimage. This constructor variant is intended to be used by developers
+   * wishing to construct a Preimage condition from a secret preimage.
+   *
+   * @param preimage An instance of {@link byte[]} containing preimage data.
    */
-  public PreimageSha256Condition(byte[] preimage) {
+  public PreimageSha256Condition(final byte[] preimage) {
     super(calculateCost(preimage));
-    this.preimage = new byte[preimage.length];
-    System.arraycopy(preimage, 0, this.preimage, 0, preimage.length);
+    this.preimage = Arrays.copyOf(preimage, preimage.length);
   }
 
   /**
-   * Constructs an instance of the condition.
-   * 
-   * @param fingerprint The calculated fingerprint for the condition.
+   * Constructs an instance of {@link PreimageSha256Condition} using a fingerprint and cost. Note
+   * that this constructor variant does not include a preimage, and is thus intended to be used
+   * to construct a condition that does not include a preimage (for example, if a condition is
+   * supplied by a remote system).
+   *
+   * @param fingerprint An instance of {@link byte[]} that contains the calculated fingerprint for
+   *     the condition.
    * @param cost The cost associated with this condition.
    */
   public PreimageSha256Condition(byte[] fingerprint, long cost) {
     super(fingerprint, cost);
+    this.preimage = null;
   }
 
   @Override
@@ -38,7 +51,9 @@ public class PreimageSha256Condition extends Sha256Condition implements SimpleCo
   }
 
   /**
-   * The PreimageSha256 fingerprint is the SHA256 hash of the raw preimage.
+   * For instances of {@link PreimageSha256Condition}, the fingerprint of a PREIMAGE-SHA-256
+   * condition is the SHA-256 hash of the *unencoded* preimage.  Thus, this method returns the
+   * preimage.
    */
   @Override
   protected byte[] getFingerprintContents() {
@@ -47,12 +62,11 @@ public class PreimageSha256Condition extends Sha256Condition implements SimpleCo
 
   /**
    * Calculates the cost of this condition, which is simply the length of the preimage.
-   * 
+   *
    * @param preimage The preimage associated with this condition.
    * @return The cost of a condition based on the preimage.
    */
   private static long calculateCost(byte[] preimage) {
     return preimage.length;
   }
-
 }

--- a/src/test/java/org/interledger/cryptoconditions/types/AbstractCryptoConditionTest.java
+++ b/src/test/java/org/interledger/cryptoconditions/types/AbstractCryptoConditionTest.java
@@ -1,0 +1,118 @@
+package org.interledger.cryptoconditions.types;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * An abstract class that unit tests can extend to gain certain useful functionality for testing
+ * purposes.
+ */
+public abstract class AbstractCryptoConditionTest {
+
+  protected final Logger logger = Logger.getLogger(this.getClass().getName());
+
+  private static final String ED_25519 = "Ed25519";
+  private static final int DEFAULT_NUM_THREADS = 100;
+
+  protected static final String AUTHOR = "Doc Brown";
+  protected static final String MESSAGE_PREIMAGE = "Roads? Where we're going, we don't need roads.";
+
+  /**
+   * Concurrently runs one or more instances of {@link Runnable} in a multithreaded fashion,
+   * relying upon the default number of threads for concurrency.
+   */
+  protected void runConcurrent(final Runnable... runnableTest) throws InterruptedException {
+    this.runConcurrent(DEFAULT_NUM_THREADS, runnableTest);
+  }
+
+  /**
+   * Concurrently runs one or more instances of {@link Runnable} in a multithreaded fashion,
+   * relying upon {@code numThreads} for concurrency.
+   */
+  protected void runConcurrent(final int numThreads, final Runnable... runnableTest)
+      throws InterruptedException {
+    final Builder<Runnable> builder = ImmutableList.builder();
+
+    // For each runnableTest, add it numThreads times to the bulider.
+    for (final Runnable runnable : runnableTest) {
+      for (int i = 0; i < numThreads; i++) {
+        builder.add(runnable);
+      }
+    }
+
+    logger.info(String.format("About to run %s threads...", numThreads));
+    // Actually runs the Runnables above using multiple threads.
+    assertConcurrent("Test did not complete before the harness timed-out. Please consider "
+        + "increasing the timeout value for this test.", builder.build(), 150);
+    logger.info(String.format("Ran %s threads!", numThreads));
+  }
+
+  private static final Logger STATIC_LOGGER = Logger
+      .getLogger(AbstractCryptoConditionTest.class.getName());
+
+  /**
+   * A new assertion method to expose concurrency bugs.
+   *
+   * @see "https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency"
+   */
+  public static void assertConcurrent(final String message,
+      final List<? extends Runnable> runnables,
+      final int maxTimeoutSeconds) throws InterruptedException {
+    final int numThreads = runnables.size();
+    final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+    final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+    try {
+      final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+      final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+      final CountDownLatch allDone = new CountDownLatch(numThreads);
+      for (final Runnable submittedTestRunnable : runnables) {
+        threadPool.submit(() -> {
+              allExecutorThreadsReady.countDown();
+              try {
+                afterInitBlocker.await();
+                submittedTestRunnable.run();
+              } catch (final Throwable e) {
+                exceptions.add(e);
+              } finally {
+                allDone.countDown();
+              }
+            }
+        );
+      }
+      // wait until all threads are ready
+      assertTrue(
+          "Timeout initializing threads! Perform long lasting initializations before "
+              + "passing runnables to assertConcurrent",
+          allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS));
+      // start all test runners
+      afterInitBlocker.countDown();
+      assertTrue(message + " timeout! More than" + maxTimeoutSeconds + "seconds",
+          allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+    } finally {
+      threadPool.shutdownNow();
+    }
+
+    exceptions.stream().forEach(e -> STATIC_LOGGER.log(Level.SEVERE, e.getMessage(), e));
+    assertTrue(
+        String.format("%s.  Exceptions: %s",
+            message,
+            exceptions.stream().map(e -> e.getMessage()).collect(Collectors.joining(", "))
+        ),
+        exceptions.isEmpty()
+    );
+  }
+
+}

--- a/src/test/java/org/interledger/cryptoconditions/types/Ed25519Sha256ConditionTest.java
+++ b/src/test/java/org/interledger/cryptoconditions/types/Ed25519Sha256ConditionTest.java
@@ -1,0 +1,85 @@
+package org.interledger.cryptoconditions.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.common.io.BaseEncoding;
+
+import net.i2p.crypto.eddsa.EdDSAPrivateKey;
+import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
+import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
+import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
+
+import org.interledger.cryptoconditions.ConditionType;
+import org.junit.Test;
+
+import java.net.URI;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * Unit tests for {@link Ed25519Sha256Condition}.
+ */
+public class Ed25519Sha256ConditionTest extends AbstractCryptoConditionTest {
+
+  private static final byte[] TEST_PUBKEY = BaseEncoding.base64()
+      .decode("Nq4bl8V3rmr7ApTpGDn6ex+TMnkbnyxdWGgZAl9KLx0=");
+
+  private static final byte[] TEST_PRIVKEY = BaseEncoding.base64()
+      .decode("A59Fwv0b/smwKKpDy66asxKeFME63RYiK0Rj6Aaf3To=");
+
+  /**
+   * Tests concurrently creating an instance of {@link Ed25519Sha256Condition}. This test validates
+   * the fix for Github issue #40 where construction of this class was not thread-safe.
+   *
+   * @see "https://github.com/interledger/java-crypto-conditions/issues/40"
+   * @see "https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency"
+   */
+  @Test
+  public void testConstructionUsingMultipleThreads() throws Exception {
+    final KeyPair keypair = this.constructEd25519KeyPair();
+
+    final Runnable runnableTest = () -> {
+      final Ed25519Sha256Condition ed25519Sha256Condition = new Ed25519Sha256Condition(
+          (EdDSAPublicKey) keypair.getPublic());
+
+      assertThat(ed25519Sha256Condition.getType(), is(ConditionType.ED25519_SHA256));
+      assertThat(ed25519Sha256Condition.getCost(), is(131072L));
+      assertThat(ed25519Sha256Condition.getUri(), is(URI.create(
+          "ni:///sha-256;aJ5kk1zn2qrQQO5QhYZXoGigv0Y5rSafiV3BUM1F9hM?cost=131072&"
+              + "fpt=ed25519-sha-256")));
+      assertThat(BaseEncoding.base64().encode(ed25519Sha256Condition.getFingerprint()),
+          is("aJ5kk1zn2qrQQO5QhYZXoGigv0Y5rSafiV3BUM1F9hM="));
+      assertThat(BaseEncoding.base64().encode(ed25519Sha256Condition.getFingerprintContents()),
+          is("MCKAIDauG5fFd65q+wKU6Rg5+nsfkzJ5G58sXVhoGQJfSi8d"));
+    };
+
+    this.runConcurrent(1, runnableTest);
+    this.runConcurrent(runnableTest);
+  }
+
+  /**
+   * Helper method to construct an instance of {@link KeyPair} containing keys for testing purposes.
+   *
+   * @return An instance of {@link KeyPair}.
+   */
+  protected KeyPair constructEd25519KeyPair() throws InvalidKeySpecException {
+    final EdDSANamedCurveSpec edParams
+        // = EdDSANamedCurveTable.getByName(ED_25519);
+        = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.CURVE_ED25519_SHA512);
+    assert (edParams != null);
+
+    final EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(TEST_PUBKEY, edParams);
+    final PublicKey pubKey = new EdDSAPublicKey(pubKeySpec);
+
+    final EdDSAPrivateKeySpec privateKeySpec = new EdDSAPrivateKeySpec(TEST_PRIVKEY, edParams);
+    final PrivateKey privKey = new EdDSAPrivateKey(privateKeySpec);
+
+    return new KeyPair(pubKey, privKey);
+  }
+}

--- a/src/test/java/org/interledger/cryptoconditions/types/PrefixSha256ConditionTest.java
+++ b/src/test/java/org/interledger/cryptoconditions/types/PrefixSha256ConditionTest.java
@@ -1,0 +1,50 @@
+package org.interledger.cryptoconditions.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.common.io.BaseEncoding;
+
+import org.interledger.cryptoconditions.ConditionType;
+import org.junit.Test;
+
+import java.net.URI;
+
+/**
+ * Unit tests for {@link PrefixSha256Condition}.
+ */
+public class PrefixSha256ConditionTest extends AbstractCryptoConditionTest {
+
+  /**
+   * Tests concurrently creating an instance of {@link PrefixSha256Condition}. This test validates
+   * the fix for Github issue #40 where construction of this class was not thread-safe.
+   *
+   * @see "https://github.com/interledger/java-crypto-conditions/issues/40"
+   * @see "https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency"
+   */
+  @Test
+  public void testConstructionUsingMultipleThreads() throws Exception {
+    final Runnable runnableTest = () -> {
+
+      final PreimageSha256Condition preimageSha256Condition = new PreimageSha256Condition(
+          MESSAGE_PREIMAGE.getBytes());
+      final PrefixSha256Condition prefixSha256Condition = new PrefixSha256Condition(
+          AUTHOR.getBytes(), 16384,
+          preimageSha256Condition);
+
+      assertThat(prefixSha256Condition.getType(), is(ConditionType.PREFIX_SHA256));
+      assertThat(prefixSha256Condition.getCost(), is(17463L));
+      assertThat(prefixSha256Condition.getUri(), is(URI.create(
+          "ni:///sha-256;hfHFYbd93301v75b1967nmZ4uLx8Pf_UYqCYYTfT_MI?cost=17463&fpt=prefix-sha-"
+              + "256&subtypes=preimage-sha-256")));
+
+      assertThat(BaseEncoding.base64().encode(prefixSha256Condition.getFingerprint()),
+          is("hfHFYbd93301v75b1967nmZ4uLx8Pf/UYqCYYTfT/MI="));
+      assertThat(BaseEncoding.base64().encode(prefixSha256Condition.getFingerprintContents()),
+          is("MDiACURvYyBCcm93boECQACiJ6AlgCD7bwRU2vus7BD9ey+slXEu+MFjfxk1mUdo8dimwhuYfoEBLg=="));
+    };
+
+    this.runConcurrent(1, runnableTest);
+    this.runConcurrent(runnableTest);
+  }
+}

--- a/src/test/java/org/interledger/cryptoconditions/types/PreimageSha256ConditionTest.java
+++ b/src/test/java/org/interledger/cryptoconditions/types/PreimageSha256ConditionTest.java
@@ -1,0 +1,47 @@
+package org.interledger.cryptoconditions.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.common.io.BaseEncoding;
+
+import org.interledger.cryptoconditions.ConditionType;
+import org.junit.Test;
+
+import java.net.URI;
+
+/**
+ * Unit tests for {@link PreimageSha256Condition}.
+ */
+public class PreimageSha256ConditionTest extends AbstractCryptoConditionTest {
+
+  private static final String PREIMAGE = "aaa";
+
+  private static final URI CONDITION_URI = URI.create("ni:///sha-256;mDSHbc-wXLFnpcJJU-uljErImxrfV_"
+      + "KPL50JrxB-6PA?cost=3&fpt=preimage-sha-256");
+
+  /**
+   * Tests concurrently creating an instance of {@link PreimageSha256Condition}. This test validates
+   * the fix for Github issue #40 where construction of this class was not thread-safe.
+   *
+   * @see "https://github.com/interledger/java-crypto-conditions/issues/40"
+   * @see "https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency"
+   */
+  @Test
+  public void testConstructionUsingMultipleThreads() throws Exception {
+    final Runnable runnableTest = () -> {
+      final PreimageSha256Condition condition = new PreimageSha256Condition(PREIMAGE.getBytes());
+
+      assertThat(condition.getType(), is(ConditionType.PREIMAGE_SHA256));
+      assertThat(condition.getCost(), is(3L));
+      assertThat(condition.getUri(), is(CONDITION_URI));
+
+      assertThat(BaseEncoding.base64().encode(condition.getFingerprint()),
+          is("mDSHbc+wXLFnpcJJU+uljErImxrfV/KPL50JrxB+6PA="));
+      assertThat(BaseEncoding.base64().encode(condition.getFingerprintContents()), is("YWFh"));
+    };
+
+    this.runConcurrent(1, runnableTest);
+    this.runConcurrent(runnableTest);
+  }
+}

--- a/src/test/java/org/interledger/cryptoconditions/types/RsaSha256ConditionTest.java
+++ b/src/test/java/org/interledger/cryptoconditions/types/RsaSha256ConditionTest.java
@@ -1,0 +1,83 @@
+package org.interledger.cryptoconditions.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.common.io.BaseEncoding;
+
+import org.interledger.cryptoconditions.ConditionType;
+import org.interledger.cryptoconditions.UnsignedBigInteger;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import java.net.URI;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+
+import java.util.Base64;
+
+/**
+ * Unit tests for {@link Ed25519Sha256Condition}.
+ */
+public class RsaSha256ConditionTest extends AbstractCryptoConditionTest {
+
+  private static final String MODULUS = "4e-LJNb3awnIHtd1KqJi8ETwSodNQ4CdMc6mEvmbDJeotDdBU-Pu89ZmFo"
+      + "Q-DkHCkyZLcbYXPbHPDWzVWMWGV3Bvzwl_cExIPlnL_f1bPue8gNdAxeDwR_PoX8DXWBV3am8_I8XcXnlxOaaILjgz"
+      + "akpfs2E3Yg_zZj264yhHKAGGL3Ly-HsgK5yJrdfNWwoHb3xT41A59n7RfsgV5bQwXMYxlwaNXm5Xm6beX04-V99eTg"
+      + "cv8s5MZutFIzlzh1J1ljnwJXv1fb1cRD-1FYzOCj02rce6AfM6C7bbsr-YnWBxEvI0TZk-d-VjwdNh3t9X2pbvLPxo"
+      + "XwArY4JGpbMJuQ";
+
+  /**
+   * Tests concurrently creating an instance of {@link Ed25519Sha256Condition}. This test validates
+   * the fix for Github issue #40 where construction of this class was not thread-safe.
+   *
+   * @see "https://github.com/interledger/java-crypto-conditions/issues/40"
+   * @see "https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency"
+   */
+  @Test
+  public void testConstructionUsingMultipleThreads() throws Exception {
+    final RSAPublicKey rsaPublicKey = this.constructRsaPublicKey();
+    final Runnable runnableTest = () -> {
+      final RsaSha256Condition rsaSha256Condition = new RsaSha256Condition(rsaPublicKey);
+
+      assertThat(rsaSha256Condition.getType(), is(ConditionType.RSA_SHA256));
+      assertThat(rsaSha256Condition.getCost(), is(65536L));
+      assertThat(rsaSha256Condition.getUri(), is(URI.create(
+          "ni:///sha-256;sx-oIG5Op-UVM3s7Mwgrh3ZRgBCF7YT7Ta6yR79pjX8?cost=65536&fpt=rsa-sha-256")));
+
+      assertThat(BaseEncoding.base64().encode(rsaSha256Condition.getFingerprint()),
+          is("sx+oIG5Op+UVM3s7Mwgrh3ZRgBCF7YT7Ta6yR79pjX8="));
+      assertThat(BaseEncoding.base64().encode(rsaSha256Condition.getFingerprintContents()),
+          is("MIIBBICCAQDh74sk1vdrCcge13UqomLwRPBKh01DgJ0xzqYS+ZsMl6i0N0FT4+7z1mYWhD4OQcKTJkt"
+              + "xthc9sc8NbNVYxYZXcG/PCX9wTEg+Wcv9/Vs+57yA10DF4PBH8+hfwNdYFXdqbz8jxdxeeXE5poguODNqS"
+              + "l+zYTdiD/NmPbrjKEcoAYYvcvL4eyArnImt181bCgdvfFPjUDn2ftF+yBXltDBcxjGXBo1eblebpt5fTj5"
+              + "X315OBy/yzkxm60UjOXOHUnWWOfAle/V9vVxEP7UVjM4KPTatx7oB8zoLttuyv5idYHES8jRNmT535WPB0"
+              + "2He31falu8s/GhfACtjgkalswm5"));
+    };
+
+    this.runConcurrent(1, runnableTest);
+    this.runConcurrent(runnableTest);
+  }
+
+
+  /**
+   * Helper method to construct an instance of {@link KeyPair} containing keys for testing purposes.
+   *
+   * @return An instance of {@link KeyPair}.
+   */
+  protected RSAPublicKey constructRsaPublicKey()
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    byte[] modulusBytes = Base64.getUrlDecoder().decode(MODULUS);
+    final BigInteger modulus = UnsignedBigInteger.fromUnsignedByteArray(modulusBytes);
+    final BigInteger exponent = BigInteger.valueOf(65537);
+    final RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+    final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    return (RSAPublicKey) keyFactory.generatePublic(spec);
+  }
+}

--- a/src/test/java/org/interledger/cryptoconditions/types/ThresholdSha256ConditionTest.java
+++ b/src/test/java/org/interledger/cryptoconditions/types/ThresholdSha256ConditionTest.java
@@ -1,0 +1,53 @@
+package org.interledger.cryptoconditions.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.interledger.cryptoconditions.ConditionType.THRESHOLD_SHA256;
+
+import com.google.common.io.BaseEncoding;
+
+import org.hamcrest.CoreMatchers;
+import org.interledger.cryptoconditions.Condition;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ThresholdSha256Condition}.
+ */
+public class ThresholdSha256ConditionTest extends AbstractCryptoConditionTest {
+
+  /**
+   * Tests concurrently creating an instance of {@link ThresholdSha256Condition}. This test
+   * validates the fix for Github issue #40 where construction of this class was not thread-safe.
+   *
+   * @see "https://github.com/interledger/java-crypto-conditions/issues/40"
+   * @see "https://github.com/junit-team/junit4/wiki/multithreaded-code-and-concurrency"
+   */
+  @Test
+  public void testConstructionUsingMultipleThreads() throws Exception {
+    final Runnable runnableTest = () -> {
+
+      final PreimageSha256Condition preimageCondition = new PreimageSha256Condition(
+          AUTHOR.getBytes());
+
+      final ThresholdSha256Condition thresholdSha256Condition = new ThresholdSha256Condition(
+          1, new Condition[]{preimageCondition}
+      );
+
+      assertThat(thresholdSha256Condition.getType(), is(THRESHOLD_SHA256));
+      assertThat(thresholdSha256Condition.getCost(), CoreMatchers.is(1033L));
+      assertThat(thresholdSha256Condition.getUri().toString(), is(
+          "ni:///sha-256;W-kFFQRd_dtz60dK3Jq0wr-DEDWHLFh8D1TQHCTi75I?cost=1033&"
+              + "fpt=threshold-sha-256&subtypes=preimage-sha-256"));
+
+      assertThat(BaseEncoding.base64().encode(thresholdSha256Condition.getFingerprint()),
+          is("W+kFFQRd/dtz60dK3Jq0wr+DEDWHLFh8D1TQHCTi75I="));
+      assertThat(BaseEncoding.base64().encode(thresholdSha256Condition.getFingerprintContents()),
+          is("MCyAAQGhJ6AlgCBjEgvXn574GWJrrBNHDMuo/bgLkhTNwoj1GUDp77vDnYEBCQ=="));
+      assertThat(BaseEncoding.base64().encode(thresholdSha256Condition.getEncoded()),
+          is("oiqAIFvpBRUEXf3bc+tHStyatMK/gxA1hyxYfA9U0Bwk4u+SgQIECYICB4A="));
+    };
+
+    this.runConcurrent(1, runnableTest);
+    this.runConcurrent(runnableTest);
+  }
+}


### PR DESCRIPTION
* Adjusts Sha256Condition to have a distinct instance of MessageDigest per-instantiation.
* Adds concurrent unit test coverage to all sub-classes of Sha256Condition to validate that operating on them in parallel does not produce corrupt results.
* Adds some extra JavaDoc to clarify various contracts.
* Misc Formatting