### PR TITLE
Fix preimage constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.interledger</groupId>
   <artifactId>java-crypto-conditions</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
 
   <name>Crypto Conditions (Java)</name>
   <description>Java implementation of the Crypto-Conditions RFC.</description>

--- a/src/main/java/org/interledger/cryptoconditions/Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/Condition.java
@@ -22,15 +22,12 @@ public interface Condition extends Comparable<Condition> {
    * the fingerprint are defined by the condition type. The fingerprint is a cryptographically
    * secure hash of the data which defines the condition, such as a public key.</p>
    *
+   * WARNING: This method MUST perform a safe copy of the internal data to protect immutability.
+   * Callers should use {@link #getFingerprintBase64Url()} instead if possible.
+   *
    * @return A read-only byte array that contains the unique fingerprint of this condition.
    *
-   * @deprecated This method may be removed in future versions, so callers should use {@link
-   *     #getFingerprintBase64Url()} instead. Java 8 does not currently have the concept of an
-   *     immutable byte array, which means outside callers could manipulate the bytes returned from
-   *     this method and unintentionally (or purposefully) mutate the internal state of this
-   *     Condition.
    */
-  @Deprecated
   byte[] getFingerprint();
 
   /**

--- a/src/main/java/org/interledger/cryptoconditions/PreimageSha256Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/PreimageSha256Condition.java
@@ -16,12 +16,16 @@ public final class PreimageSha256Condition extends Sha256Condition implements Si
 
   /**
    * Required-args Constructor.  Constructs an instance of {@link PreimageSha256Condition} based
-   * on a supplied preimage. This constructor variant is intended to be used by developers
-   * wishing to construct a Preimage condition from a secret preimage.
+   * on a supplied preimage.
+   *
+   * Note this constructor is package-private because it is only used from within {@link PreimageSha256Fulfillment}.
+   *
+   * Developers that wish to create a new {@link PreimageSha256Condition} from the preimage should instead create a new
+   * {@link PreimageSha256Fulfillment} and call {@link PreimageSha256Fulfillment#getCondition()}.
    *
    * @param preimage An instance of byte array containing preimage data.
    */
-  public PreimageSha256Condition(final byte[] preimage) {
+  PreimageSha256Condition(final byte[] preimage) {
     super(
         CryptoConditionType.PREIMAGE_SHA256,
         calculateCost(preimage),
@@ -37,12 +41,11 @@ public final class PreimageSha256Condition extends Sha256Condition implements Si
    * to construct a condition that does not include a preimage (for example, if a condition is
    * supplied by a remote system).
    * <p/>
-   * Note this constructor is package-private because it is used primarily for testing purposes.
    *
    * @param cost        The cost associated with this condition.
    * @param fingerprint An instance of byte array that contains the calculated fingerprint for
    */
-  PreimageSha256Condition(final long cost, final byte[] fingerprint) {
+  public PreimageSha256Condition(final long cost, final byte[] fingerprint) {
     super(PREIMAGE_SHA256, cost, fingerprint);
   }
 

--- a/src/main/java/org/interledger/cryptoconditions/PreimageSha256Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/PreimageSha256Condition.java
@@ -18,14 +18,16 @@ public final class PreimageSha256Condition extends Sha256Condition implements Si
    * Required-args Constructor.  Constructs an instance of {@link PreimageSha256Condition} based
    * on a supplied preimage.
    *
-   * Note this constructor is package-private because it is only used from within {@link PreimageSha256Fulfillment}.
+   * @deprecated This constructor will be made package-private in future versions because it is only used from within
+   * {@link PreimageSha256Fulfillment}.
    *
-   * Developers that wish to create a new {@link PreimageSha256Condition} from the preimage should instead create a new
+   * <p>Developers that wish to create a new {@link PreimageSha256Condition} from the preimage should instead create a new
    * {@link PreimageSha256Fulfillment} and call {@link PreimageSha256Fulfillment#getCondition()}.
    *
    * @param preimage An instance of byte array containing preimage data.
    */
-  PreimageSha256Condition(final byte[] preimage) {
+  @Deprecated
+  public PreimageSha256Condition(final byte[] preimage) {
     super(
         CryptoConditionType.PREIMAGE_SHA256,
         calculateCost(preimage),
@@ -50,11 +52,13 @@ public final class PreimageSha256Condition extends Sha256Condition implements Si
 
   /**
    * Constructs the fingerprint for this condition.
-   * <p/>
-   * Note: This method is package-private as (opposed to private) for testing purposes.
+   *
+   * <p>Note: This method is package-private as (opposed to private) for testing purposes.
+   *
+   * @param preimage An instance of byte array containing preimage data.
    */
-  static final byte[] constructFingerprintContents(final byte[] prefix) {
-    return Objects.requireNonNull(prefix);
+  static final byte[] constructFingerprintContents(final byte[] preimage) {
+    return Objects.requireNonNull(preimage);
   }
 
   /**

--- a/src/main/java/org/interledger/cryptoconditions/PreimageSha256Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/PreimageSha256Condition.java
@@ -40,7 +40,6 @@ public final class PreimageSha256Condition extends Sha256Condition implements Si
    * that this constructor variant does not include a preimage, and is thus intended to be used
    * to construct a condition that does not include a preimage (for example, if a condition is
    * supplied by a remote system).
-   * <p/>
    *
    * @param cost        The cost associated with this condition.
    * @param fingerprint An instance of byte array that contains the calculated fingerprint for

--- a/src/main/java/org/interledger/cryptoconditions/Sha256Condition.java
+++ b/src/main/java/org/interledger/cryptoconditions/Sha256Condition.java
@@ -34,14 +34,13 @@ public abstract class Sha256Condition extends ConditionBase {
     }
 
     Objects.requireNonNull(fingerprint);
-    this.fingerprint = Arrays.copyOf(fingerprint, fingerprint.length);
-    this.fingerprintBase64Url = Base64.getUrlEncoder().encodeToString(this.fingerprint);
+    this.fingerprint = Arrays.copyOf(fingerprint, 32);
+    this.fingerprintBase64Url = Base64.getUrlEncoder().withoutPadding().encodeToString(this.fingerprint);
   }
 
-  @Deprecated
   @Override
   public final byte[] getFingerprint() {
-    return fingerprint;
+    return Arrays.copyOf(fingerprint, 32);
   }
 
   @Override

--- a/src/test/java/org/interledger/cryptoconditions/helpers/TestVectorFactory.java
+++ b/src/test/java/org/interledger/cryptoconditions/helpers/TestVectorFactory.java
@@ -45,9 +45,9 @@ public class TestVectorFactory {
     switch (type) {
 
       case PREIMAGE_SHA256: {
-        return new PreimageSha256Condition(
+        return new PreimageSha256Fulfillment(
             Base64.getUrlDecoder().decode(testVectorJson.getPreimage())
-        );
+        ).getCondition();
       }
 
       case PREFIX_SHA256: {


### PR DESCRIPTION
See https://github.com/interledger/java-ilp-core/pull/102
Remove deprecation annotation from Condition.getFingerprint()
- Add warning to JavaDoc about safe copy
- Implement safe copy in Sha256Condition